### PR TITLE
Fix V562 warning from PVS-Studio Static Analyzer

### DIFF
--- a/cvs_direct.c
+++ b/cvs_direct.c
@@ -775,7 +775,7 @@ static int parse_patch_arg(char * arg, char ** str)
     if (!tok)
 	return 0;
 
-    if (!*tok == '-')
+    if (!(*tok == '-'))
     {
 	debug(DEBUG_APPERROR, "diff_opts parse error: no '-' starting argument: %s", *str);
 	return 0;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
It's odd to compare 0 or 1 with a value of 45: !* tok == '-'.
Operation ! executes before ==